### PR TITLE
Added convenience which removes the need to copy .dll's to unity's application folder. 

### DIFF
--- a/libpd4unity/Assets/LibPdFilterRead.cs
+++ b/libpd4unity/Assets/LibPdFilterRead.cs
@@ -24,6 +24,8 @@ public class LibPdFilterRead : MonoBehaviour
 	// Pd initialisation and patch open on game awake
 	void Awake ()
 	{	
+		PluginUtils.ResolvePath();
+
 		// Delegate for 'print' 
 		LibPD.Print += ReceivePrint;
 

--- a/libpd4unity/Assets/PluginUtils.cs
+++ b/libpd4unity/Assets/PluginUtils.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.IO;
+using UnityEngine;
+
+public class PluginUtils
+{
+	public static void ResolvePath()
+	{
+		String currentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Process);
+		String dllPath = Application.dataPath + "/" + "Plugins";
+		dllPath.Replace("/", Path.DirectorySeparatorChar.ToString()); // Correct dir format for win platforms 
+		if (currentPath.Contains(dllPath) == false)
+		{
+			Environment.SetEnvironmentVariable("PATH", currentPath + Path.PathSeparator + dllPath, EnvironmentVariableTarget.Process);
+		}
+	}
+}

--- a/libpd4unity/Assets/PluginUtils.cs.meta
+++ b/libpd4unity/Assets/PluginUtils.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: adfcc43dab94b754795dd9aa9853b1ea
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 


### PR DESCRIPTION
Using the strategy as described here http://forum.unity3d.com/threads/31083-DllNotFoundException-when-depend-on-another-dll/page2 , PluginUtils.cs dynamically appends the plugins folder to the environment PATH variable. The circumvents the need to copy anything to the Unity.exe application folder - which is pretty gross. 

Tested on Win and OSX. 
